### PR TITLE
net: improve GetIPAddresses()

### DIFF
--- a/net.go
+++ b/net.go
@@ -58,14 +58,18 @@ func GetIPAddresses(ifaces ...string) ([]netip.Addr, error) {
 			return out, err
 		}
 
-		for _, netAddr := range addrs {
-			addr, err := netip.ParseAddr(netAddr.String())
-			if err != nil {
-				return out, err
+		for _, addr := range addrs {
+			var s []byte
+
+			switch v := addr.(type) {
+			case *net.IPAddr:
+				s = v.IP
+			case *net.IPNet:
+				s = v.IP
 			}
 
-			if addr.IsValid() {
-				out = append(out, addr)
+			if ip, ok := netip.AddrFromSlice(s); ok {
+				out = append(out, ip)
 			}
 		}
 	}

--- a/net.go
+++ b/net.go
@@ -69,7 +69,7 @@ func GetIPAddresses(ifaces ...string) ([]netip.Addr, error) {
 			}
 
 			if ip, ok := netip.AddrFromSlice(s); ok {
-				out = append(out, ip)
+				out = append(out, ip.Unmap())
 			}
 		}
 	}
@@ -83,14 +83,9 @@ func GetStringIPAddresses(ifaces ...string) ([]string, error) {
 
 	out := make([]string, 0, len(addrs))
 	for _, addr := range addrs {
-
-		if addr.Is4In6() {
-			addr = addr.Unmap()
-		} else {
-			addr = addr.WithZone("")
+		if addr.IsValid() {
+			out = append(out, addr.String())
 		}
-
-		out = append(out, addr.String())
 	}
 
 	return out, err

--- a/net.go
+++ b/net.go
@@ -39,14 +39,14 @@ func GetIPAddresses(ifaces ...string) ([]netip.Addr, error) {
 	var out []netip.Addr
 
 	if len(ifaces) == 0 {
-		var err error
+		// all addresses
+		addrs, err := net.InterfaceAddrs()
+		out = appendNetIPAsIP(out, addrs...)
 
-		ifaces, err = GetInterfacesNames()
-		if err != nil {
-			return out, err
-		}
+		return out, err
 	}
 
+	// only given interfaces
 	for _, name := range ifaces {
 		ifi, err := net.InterfaceByName(name)
 		if err != nil {

--- a/net.go
+++ b/net.go
@@ -58,23 +58,29 @@ func GetIPAddresses(ifaces ...string) ([]netip.Addr, error) {
 			return out, err
 		}
 
-		for _, addr := range addrs {
-			var s []byte
-
-			switch v := addr.(type) {
-			case *net.IPAddr:
-				s = v.IP
-			case *net.IPNet:
-				s = v.IP
-			}
-
-			if ip, ok := netip.AddrFromSlice(s); ok {
-				out = append(out, ip.Unmap())
-			}
-		}
+		out = appendNetIPAsIP(out, addrs...)
 	}
 
 	return out, nil
+}
+
+func appendNetIPAsIP(out []netip.Addr, addrs ...net.Addr) []netip.Addr {
+	for _, addr := range addrs {
+		var s []byte
+
+		switch v := addr.(type) {
+		case *net.IPAddr:
+			s = v.IP
+		case *net.IPNet:
+			s = v.IP
+		}
+
+		if ip, ok := netip.AddrFromSlice(s); ok {
+			out = append(out, ip.Unmap())
+		}
+	}
+
+	return out
 }
 
 // GetStringIPAddresses returns IP addresses as string


### PR DESCRIPTION
revert usage of netip.ParseAddr() because it doesn't handle cidr properly
and simplify the case where no interfaces are specified